### PR TITLE
Update list of static checkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a file to keep track of all of the type checkers that exist for Python. 
 - [pyrefly](https://pyreflycheck.org/)
 - [pyright](https://github.com/Microsoft/pyright)
 - [ty](https://docs.astral.sh/ty)
+- [zuban](https://zubanls.com/)
 - [PyCharm](https://www.jetbrains.com/pycharm/) (IDE inference engine)
 - [pyre](https://pyre-check.org/) ([superseded by pyrefly](https://github.com/facebook/pyre-check/pull/987))
 - [pytype](https://github.com/google/pytype) ([abandoned](https://github.com/google/pytype/issues/1925))

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ This is a file to keep track of all of the type checkers that exist for Python. 
 ### Static
 
 - [mypy](https://github.com/python/mypy)
-- [pyre](https://pyre-check.org/)
-- [pytype](https://github.com/google/pytype)
-- [PyCharm](https://www.jetbrains.com/pycharm/)
+- [pyrefly](https://pyreflycheck.org/)
 - [pyright](https://github.com/Microsoft/pyright)
+- [ty](https://docs.astral.sh/ty)
+- [PyCharm](https://www.jetbrains.com/pycharm/) (IDE inference engine)
+- [pyre](https://pyre-check.org/) ([superseded by pyrefly](https://github.com/facebook/pyre-check/pull/987))
+- [pytype](https://github.com/google/pytype) ([abandoned](https://github.com/google/pytype/issues/1925))
 
 ### Dynamic/Runtime
 


### PR DESCRIPTION
- add pyrefly (replacing pyre it supersedes) and ty
- add zuban (which I just found out about)
- move pycharm down the list (probably less useful to most as it's an IDE inference engine)
- move pyre and pytype down the list as they are abandoned

Fixes #8